### PR TITLE
docs(prebuilt): Fix extension typo

### DIFF
--- a/src/content/docs/references/getting-started/prebuilt-binaries.md
+++ b/src/content/docs/references/getting-started/prebuilt-binaries.md
@@ -42,7 +42,7 @@ afterwards you can double click the python file and pick "python" from the list.
 13. click on "new" and paste the path to the folder
 14. run `c3c` on anywhere in your computer!
 ```bash
-c3c compile ./hello.c3c
+c3c compile ./hello.c3
 ```
 
 ## Installing on Debian


### PR DESCRIPTION
Destination: https://c3-lang.org/references/getting-started/prebuilt-binaries/
Source: 

https://github.com/c3lang/c3-web/blob/98f03610b6086165abb7c5da5720ca95d29ba282/src/content/docs/references/getting-started/prebuilt-binaries.md?plain=1#L44-L46