### PR TITLE
Detect OS for download button

### DIFF
--- a/src/components/download.astro
+++ b/src/components/download.astro
@@ -1,0 +1,93 @@
+<div class="mt-5 gap-3">
+  <div>
+    <a
+      id="download-button"
+      href="https://google.com"
+      onclick="openLink()"
+      class="py-3 px-4 inline-flex justify-center items-center gap-2 rounded-l-md border font-medium text-gray-700 dark:text-gray-400 shadow-sm bg-white dark:bg-stone-950 hover:bg-blue-500 focus:z-10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm dark:hover:bg-slate-800 dark:border-gray-700 dark:hover:text-white dark:focus:ring-offset-gray-800"
+    >
+      Download for Windows
+    </a>
+    <div
+      class="mr-5 hs-dropdown relative inline-flex [--placement:bottom-right]"
+    >
+      <button
+        id="hs-split-dropdown"
+        type="button"
+        class="bg-white dark:bg-stone-950 hs-dropdown-toggle relative -ml-[.3125rem] py-3 px-4 inline-flex justify-center items-center gap-2 h-[2.875rem] w-[2.875rem] rounded-r-md border font-medium text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800"
+      >
+        <span class="sr-only">Toggle Dropdown</span>
+        <svg
+          class="hs-dropdown-open:rotate-180 w-2.5 h-2.5 text-gray-600"
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M2 5L8.16086 10.6869C8.35239 10.8637 8.64761 10.8637 8.83914 10.6869L15 5"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"></path>
+        </svg>
+      </button>
+
+      <div
+        class="hs-dropdown-menu w-72 transition-[opacity,margin] duration hs-dropdown-open:opacity-100 opacity-0 hidden z-10 bg-white shadow-md rounded-lg p-2 mt-2 dark:bg-stone-950 dark:border dark:border-gray-700 dark:divide-gray-700"
+        aria-labelledby="hs-split-dropdown"
+      >
+        <a
+          id="windows-download"
+          style="display: none;"
+          class="flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+          href="https://github.com/c3lang/c3c/releases/download/latest/c3-windows.zip"
+        >
+          Windows
+        </a>
+        <a
+          id="macos-download"
+          class="flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+          href="https://github.com/c3lang/c3c/releases/download/latest/c3-macos.zip"
+        >
+          macOS
+        </a>
+        <a
+          id="linux-download"
+          class="flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+          href="https://github.com/c3lang/c3c/releases/download/latest/c3-linux.tar.gz"
+        >
+          Linux
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+const userAgent = window.navigator.userAgent.toLowerCase();
+const os =
+  userAgent.indexOf("linux") != -1
+    ? "Linux"
+    : userAgent.indexOf("mac") != -1
+    ? "MacOS"
+    : userAgent.indexOf("win") != -1
+    ? "Windows"
+    : "Unknown";
+
+const downloadButton = document.getElementById("download-button");
+const windowsDownloadLink = document.getElementById("windows-download");
+const macosDownloadLink = document.getElementById("macos-download");
+const linuxDownloadLink = document.getElementById("linux-download");
+if (os == "MacOS") {
+  downloadButton.setAttribute("href", "https://github.com/c3lang/c3c/releases/download/latest/c3-macos.zip")
+  downloadButton.innerText = "Download for MacOS";
+  windowsDownloadLink.style.setProperty("display", "block");
+  macosDownloadLink.style.setProperty("display", "none");
+} else if (os == "Linux") {
+  downloadButton.setAttribute("href", "https://github.com/c3lang/c3c/releases/download/latest/c3-linux.tar.gz")
+  downloadButton.innerText = "Download for Linux";
+  windowsDownloadLink.style.setProperty("display", "block");
+  linuxDownloadLink.style.setProperty("display", "none");
+}
+</script>

--- a/src/components/download.astro
+++ b/src/components/download.astro
@@ -2,7 +2,7 @@
   <div>
     <a
       id="download-button"
-      href="https://google.com"
+      href="https://github.com/c3lang/c3c/releases/download/latest/c3-windows.zip"
       onclick="openLink()"
       class="py-3 px-4 inline-flex justify-center items-center gap-2 rounded-l-md border font-medium text-gray-700 dark:text-gray-400 shadow-sm bg-white dark:bg-stone-950 hover:bg-blue-500 focus:z-10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm dark:hover:bg-slate-800 dark:border-gray-700 dark:hover:text-white dark:focus:ring-offset-gray-800"
     >

--- a/src/components/sample.astro
+++ b/src/components/sample.astro
@@ -1,3 +1,6 @@
+---
+import DownloadButton from './download.astro'
+---
 <main>
   <div class="max-w-[85rem] mx-auto px-4 sm:px-6 lg:px-8">
     <div class="grid md:grid-cols-2 gap-4 md:gap-8 xl:gap-20 md:items-center">
@@ -15,60 +18,7 @@
         <p class="mt-3 text-lg text-gray-800 dark:text-gray-400 mb-5">
           Simple, fast, safe, compiled. For developing maintainable software.
         </p>
-        <div class="mt-5 gap-3">
-          <div class="">
-            <button
-              type="button"
-              onclick="window.location.href='https://github.com/c3lang/c3c/releases/download/latest/c3-windows.zip'"
-              class="py-3 px-4 inline-flex justify-center items-center gap-2 rounded-l-md border font-medium text-gray-700 dark:text-gray-400 shadow-sm bg-white dark:bg-stone-950 hover:bg-blue-500 focus:z-10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm dark:hover:bg-slate-800 dark:border-gray-700 dark:hover:text-white dark:focus:ring-offset-gray-800"
-            >
-              Download for Windows
-            </button>
-            <div
-              class="mr-5 hs-dropdown relative inline-flex [--placement:bottom-right]"
-            >
-              <button
-                id="hs-split-dropdown"
-                type="button"
-                class="bg-white dark:bg-stone-950 hs-dropdown-toggle relative -ml-[.3125rem] py-3 px-4 inline-flex justify-center items-center gap-2 h-[2.875rem] w-[2.875rem] rounded-r-md border font-medium text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800"
-              >
-                <span class="sr-only">Toggle Dropdown</span>
-                <svg
-                  class="hs-dropdown-open:rotate-180 w-2.5 h-2.5 text-gray-600"
-                  width="16"
-                  height="16"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M2 5L8.16086 10.6869C8.35239 10.8637 8.64761 10.8637 8.83914 10.6869L15 5"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"></path>
-                </svg>
-              </button>
-
-              <div
-                class="hs-dropdown-menu w-72 transition-[opacity,margin] duration hs-dropdown-open:opacity-100 opacity-0 hidden z-10 bg-white shadow-md rounded-lg p-2 mt-2 dark:bg-stone-950 dark:border dark:border-gray-700 dark:divide-gray-700"
-                aria-labelledby="hs-split-dropdown"
-              >
-                <a
-                  class="flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300"
-                  href="https://github.com/c3lang/c3c/releases/download/latest/c3-macos.zip"
-                >
-                  macOS
-                </a>
-                <a
-                  class="flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300"
-                  href="https://github.com/c3lang/c3c/releases/download/latest/c3-linux.tar.gz"
-                >
-                  Linux
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
+        <DownloadButton />
       </div>
       <div class="relative">
         <div class="flex items-center justify-center">


### PR DESCRIPTION
This changes the download button based on which OS the button was opened on.

Defaults to Windows, for when JS is disabled, and also for when the OS was not one of the 3 supported ones (like Android).

Demo from my MacBook:

<img width="500" alt="Screenshot 2024-07-29 at 11 24 35 PM" src="https://github.com/user-attachments/assets/98d4f9c2-d52c-45d1-8511-bff6dd12af66">

This also fixes the problem of the download button not working on JS-disabled browsers.