### PR TITLE
Remove invalid 'pseudo associated values' for enum

### DIFF
--- a/src/content/docs/references/getting-started/primer.md
+++ b/src/content/docs/references/getting-started/primer.md
@@ -146,8 +146,8 @@ Name standards are enforced:
     const int FOOBAR = 123;
     enum Test
     {
-      STATE_A = 0,
-      STATE_B = 2
+      STATE_A,
+      STATE_B
     }
 
 #### Variable declaration


### PR DESCRIPTION
This way of defining enum values doesn't work, and errors in "Error: No associated values are defined for this enum."