### PR TITLE
Change interface method argument to pointer

### DIFF
--- a/src/content/docs/references/docs/anyinterfaces.md
+++ b/src/content/docs/references/docs/anyinterfaces.md
@@ -104,7 +104,7 @@ To declare that a type implements an interface, add it after the type name:
     }
 
     // Note how the first argument differs from the interface.
-    fn String Baz.myname(Baz self) @dynamic 
+    fn String Baz.myname(Baz* self) @dynamic 
     { 
         return "I am Baz!"; 
     }


### PR DESCRIPTION
This errors in

```
Error: The first parameter must always be a pointer for '@dynamic' methods, so please change its type to 'Baz*' if possible.
```