### PR TITLE
Add @extern info to cinterop

### DIFF
--- a/src/content/docs/references/docs/cinterop.md
+++ b/src/content/docs/references/docs/cinterop.md
@@ -9,52 +9,59 @@ C3 is C ABI compatible. That means you can call C from C3, and call C3 from C wi
 do anything special. As a quick way to call C, you can simply declare the function as a 
 C3 function but with `extern` in front of it. As long as the function is linked, it will work:
 
-    extern fn void puts(char*); // C "puts"
+```c3
+extern fn void puts(char*); // C "puts"
 
-    fn void main()
-    {
-        // This will call the "puts"
-        // function in the standard c lib.
-        puts("Hello, world!"); 
-    }
+fn void main()
+{
+    // This will call the "puts"
+    // function in the standard c lib.
+    puts("Hello, world!"); 
+}
+```
 
 To use a different identifier inside of your C3 code compared to the function or variable’s external name, use the @extern attribute:
 
-    extern fn void foo_puts(char*) @extern("puts"); // C "puts"
+```c3
+extern fn void foo_puts(char*) @extern("puts"); // C "puts"
 
-    fn void main()
-    {
-        foo_puts("Hello, world!"); // Still calls C "puts"
-    }
+fn void main()
+{
+    foo_puts("Hello, world!"); // Still calls C "puts"
+}
+```
 
 While C3 functions are available from C using their external name, it's often useful to
 define an external name using `@extern` to match C usage.
 
+```c3
+module foo;
+fn int square(int x)
+{
+    return x * x;
+}
 
-    module foo;
-    fn int square(int x)
-    {
-        return x * x;
-    }
-
-    fn int square2(int x) @extern("square")
-    {
-        return x * x;
-    }
+fn int square2(int x) @extern("square")
+{
+    return x * x;
+}
+```
 
 Calling from C:
 
-    extern int square(int);
-    int foo_square(int) __attribute__ ((weak, alias ("foo.square")));
+```c3
+extern int square(int);
+int foo_square(int) __attribute__ ((weak, alias ("foo.square")));
 
-    void test()
-    {
-        // This would call square2
-        printf("%d\n", square(11));
+void test()
+{
+    // This would call square2
+    printf("%d\n", square(11));
 
-        // This would call square
-        printf("%d\n", foo_square(11));
-    }
+    // This would call square
+    printf("%d\n", foo_square(11));
+}
+```
 
 ## Linking static and dynamic libraries
 

--- a/src/content/docs/references/docs/cinterop.md
+++ b/src/content/docs/references/docs/cinterop.md
@@ -18,6 +18,15 @@ C3 function but with `extern` in front of it. As long as the function is linked,
         puts("Hello, world!"); 
     }
 
+To use a different identifier inside of your C3 code compared to the function or variable’s external name, use the @extern attribute:
+
+    extern fn void foo_puts(char*) @extern("puts"); // C "puts"
+
+    fn void main()
+    {
+        foo_puts("Hello, world!"); // Still calls C "puts"
+    }
+
 While C3 functions are available from C using their external name, it's often useful to
 define an external name using `@extern` to match C usage.
 


### PR DESCRIPTION
Took me a while to find the solution in [a quick primer on C3](https://c3-lang.org/references/getting-started/primer/) under "Calling C functions" so it may be useful to have it on the dedicated cinterop page which a lot of people will naturally look at first (like I did).