### PR TITLE
Fix dead link in Contribution

### DIFF
--- a/src/content/docs/references/development/index.md
+++ b/src/content/docs/references/development/index.md
@@ -12,6 +12,6 @@ So if you find the project interesting, here's what you can do to help:
 
 
 - Discuss the language on the C3 Discord [https://discord.gg/qN76R87](https://discord.gg/qN76R87) 
-- Suggest improvements by filing an issue: [https://github.com/c3lang/c3docs/issues/new](https://github.com/c3lang/c3docs/issues/new)
+- Suggest improvements by filing an issue: [https://github.com/c3lang/c3docs/issues/new](https://github.com/c3lang/c3c/issues/new)
+- Spotted a typo or found a broken link? [https://github.com/c3lang/c3-web/issues/new](https://github.com/c3lang/c3-web/issues/new)
 - Offer to work on the compiler being written here: [https://github.com/c3lang/c3c](https://github.com/c3lang/c3c)
-

--- a/src/content/docs/references/development/index.md
+++ b/src/content/docs/references/development/index.md
@@ -12,6 +12,6 @@ So if you find the project interesting, here's what you can do to help:
 
 
 - Discuss the language on the C3 Discord [https://discord.gg/qN76R87](https://discord.gg/qN76R87) 
-- Suggest improvements by filing an issue: [https://github.com/c3lang/c3docs/issues/new](https://github.com/c3lang/c3c/issues/new)
+- Suggest improvements by filing an issue: [https://github.com/c3lang/c3c/issues/new](https://github.com/c3lang/c3c/issues/new)
 - Spotted a typo or found a broken link? [https://github.com/c3lang/c3-web/issues/new](https://github.com/c3lang/c3-web/issues/new)
 - Offer to work on the compiler being written here: [https://github.com/c3lang/c3c](https://github.com/c3lang/c3c)


### PR DESCRIPTION
This fixes the dead link for filing an issue. Points to c3 repo instead of docs. Added a new link for documentation related issues.