### PR TITLE
Remove deprecated items from compiletime

### DIFF
--- a/src/content/docs/references/docs/compiletime.md
+++ b/src/content/docs/references/docs/compiletime.md
@@ -223,11 +223,6 @@ A set of compile time functions are available at compile time:
 
 Get the alignment of something. See [reflection](../reflection).
 
-### `$and`
-
-Evaluate a list of constant boolean expressions at compile time, stopping
-evaluation if a `false` result is found.
-
 ### `$append`
 
 Append a compile time constant to a compile time array or untyped list.
@@ -239,10 +234,6 @@ Check a condition at compile time.
 ### `$assignable`
 
 Check if an expression is assignable to the given type, e.g. `Type x = expr;` would be valid.
-
-### `$concat`
-
-Concatenate two constant arrays, strings or untyped lists at compile time.
 
 ### `$defined`
 
@@ -291,11 +282,6 @@ Get the local name of a symbol. See [reflection](../reflection).
 ### `$offsetof`
 
 Get the offset of a member. See [reflection](../reflection).
-
-### `$or`
-
-Evaluate a list of constant boolean expressions at compile time, stopping
-evaluation if a `true` result is found.
 
 ### `$qnameof`
 

--- a/src/content/docs/references/docs/macros.md
+++ b/src/content/docs/references/docs/macros.md
@@ -16,12 +16,12 @@ The macro capabilities of C3 reaches across several constructs: macros (prefixed
     #endif
     
     // C3
-    $if $defined(x) && $y > 3:
+    $if $defined(x) && Y > 3:
         int z;
     $endif
 
     // or
-    int z @if($defined(x) && $y > 3);
+    int z @if($defined(x) && Y > 3);
 
     
 
@@ -102,7 +102,7 @@ in C3 the captured argument isn't automatically dereferenced)
     
     
     // C3
-    macro for_each(list; @body(it))
+    macro @for_each(list; @body(it))
     {
         for ($typeof(list) x = list; x; x = x.next)
         {
@@ -136,8 +136,8 @@ in C3 the captured argument isn't automatically dereferenced)
     int foo(int x) PURE_INLINE { ... }
     
     // C3
-    define @PureInline = { @pure @inline };
-    fn int foo(int) @PureInline { ... }    
+    def @NoDiscardInline = { @nodiscard @inline };
+    fn int foo(int) @NoDiscardInline { ... }
 
 
 ### Declaration macros
@@ -338,7 +338,7 @@ the arguments:
     {
        var $x = 0;
        $for (var $i = 0; $i < $vacount; $i++)
-           $x += $vaconst($i);
+           $x += $vaconst[$i];
        $endfor
        return $x;
     }
@@ -385,7 +385,7 @@ arguments 2, 3 and 4).
 
 Nor is it limited to function arguments, you can also use it with initializers:
 
-    int[*] a = { 5, $vasplat(2..), 77 };
+    int[*] a = { 5, $vasplat[2..], 77 };
 
 ## Untyped lists
 


### PR DESCRIPTION
Recently removed as part of 0.6.2
- $concat
- $and
- $or