### PR TITLE
Added examples for some parts of the standard library 

### DIFF
--- a/src/content/docs/Standard Library/index.mdx
+++ b/src/content/docs/Standard Library/index.mdx
@@ -416,27 +416,28 @@ See `print` for usage.
 Regular printf functionality: `%s`, `%x`, `%d`, `%f` and `%p` are supported.
 Will also print enums and vectors. Prints to stdout.
 
-```c
+```c3
 import std::io;
 
-enum Heat {
+enum Heat 
+{
     WARM,
     WARMER,
     REALLY_WARM,
 }
 
-fn void main() {
-    int[<2>] vec = {4, 2};
+fn void main() 
+{
+    int[<2>] vec = { 4, 2 };
     Heat weather = REALLY_WARM;
     String dialogue = "Hello";
 
-    io::printf("%s", dialogue);  /* Outputs: Hello    */
-    io::printf("%d", 20);        /* Outputs: 20       */
-    io::printf("%f", 2.2);       /* Outputs: 2.200000 */
-    io::printf("%s", vec);       /* Outputs: [<4, 2>] */
-    io::printf("%s", weather);   /* Outputs: REALLY_WARM */
+    io::printfn("%s", dialogue);  // Hello
+    io::printfn("%d", 20);        // 20
+    io::printfn("%f", 2.2);       // 2.200000
+    io::printfn("%s", vec);       // [<4, 2>]
+    io::printfn("%s", weather);   // REALLY_WARM
 }
-```
 
 Also available as `printfn` which appends a newline.
 

--- a/src/content/docs/Standard Library/index.mdx
+++ b/src/content/docs/Standard Library/index.mdx
@@ -354,7 +354,7 @@ Note:
 `\r` will be filtered from the String.
 
 ### String! treadline(stream = io::stdin())
-Read a `String!` from a file stream. Defaults to standard input (stdin). Reads to the next newline or to the end of stream. `Treadline` returns an optional, and must be handled accordingly. Additionally, the difference from the regular `readline`, is that this uses the temporary allocator.
+Read a `String!` from a file stream which is standard input (stdin) by default, Reads to the next newline character `\n` or to the end of stream. `Treadline` returns an [Optional](/language-common/optionals-essential/#what-is-an-optional) string. The temporary allocator is used by `Treadline`, in contrast the `readline` defaults to the heap allocator, but is configurable to other allocators. 
 
 ```c
 import std::io;

--- a/src/content/docs/Standard Library/index.mdx
+++ b/src/content/docs/Standard Library/index.mdx
@@ -376,9 +376,32 @@ Note:
 `\r` will be filtered from the String.
 
 ### void print(x), void printn(x = "")
-Print any value to stdout.
-
+Print a value to stdout. Works for different types. 
 The `printn` variant appends a newline.
+```c
+import std::io;
+
+enum Heat {
+    WARM,
+    WARMER,
+    REALLY_WARM,
+}
+
+fn void main() {
+    int[<2>] vec = {4, 2};
+    Heat weather = WARM;
+    int[5] fib = { 0, 1, 1, 2, 3 };
+    String dialogue = "I will never tell you about the muffin man";
+
+    io::print("Hello");   /* Outputs: Hello                                      */
+    io::print(20);        /* Outputs: 20                                         */
+    io::print(2.2);       /* Outputs: 2.200000                                   */
+    io::print(vec);       /* Outputs: [<4, 2>]                                   */
+    io::print(weather);   /* Outputs: WARM                                       */
+    io::print(fib);       /* Outputs: [0, 1, 1, 2, 3]                            */
+    io::print(dialogue);  /* Outputs: I will never tell you about the muffin man */
+}
+```
 
 ### void eprint(x), void eprintn(x)
 Print any value to stderr.

--- a/src/content/docs/Standard Library/index.mdx
+++ b/src/content/docs/Standard Library/index.mdx
@@ -376,32 +376,35 @@ fn void! main() {
 :::
 
 ### void print(x), void printn(x = "")
-Print a value to stdout. Works for different types. 
+
+Print a value to stdout works for the majority of types, including structs, which can be helpful for debugging.
 The `printn` variant appends a newline.
-```c
+
+```c3
 import std::io;
 
-enum Heat {
+enum Heat 
+{
     WARM,
     WARMER,
     REALLY_WARM,
 }
 
-fn void main() {
-    int[<2>] vec = {4, 2};
+fn void main() 
+{
+    int[<2>] vec = { 4, 2 };
     Heat weather = WARM;
     int[5] fib = { 0, 1, 1, 2, 3 };
-    String dialogue = "I will never tell you about the muffin man";
+    String dialogue = "secret";
 
-    io::print("Hello");   /* Outputs: Hello                                      */
-    io::print(20);        /* Outputs: 20                                         */
-    io::print(2.2);       /* Outputs: 2.200000                                   */
-    io::print(vec);       /* Outputs: [<4, 2>]                                   */
-    io::print(weather);   /* Outputs: WARM                                       */
-    io::print(fib);       /* Outputs: [0, 1, 1, 2, 3]                            */
-    io::print(dialogue);  /* Outputs: I will never tell you about the muffin man */
+    io::print("Hello");   // Hello
+    io::print(20);        // 20
+    io::print(2.2);       // 2.200000
+    io::print(vec);       // [<4, 2>]
+    io::print(weather);   // WARM
+    io::print(fib);       // [0, 1, 1, 2, 3] 
+    io::print(dialogue);  // secret
 }
-```
 
 ### void eprint(x), void eprintn(x)
 Print any value to stderr.

--- a/src/content/docs/Standard Library/index.mdx
+++ b/src/content/docs/Standard Library/index.mdx
@@ -336,20 +336,19 @@ moving the output pointer 1 or 2 steps.
 ### String! readline(stream = io::stdin(), Allocator allocator = allocator::heap())
 Read a `String!` from a file stream, which is standard input (stdin) by default, reads to the next newline character `\n` or to the end of stream. `Readline` returns an [Optional](/language-common/optionals-essential/#what-is-an-optional) string.
 
-```c
+```c3
 import std::io;
 
-fn void! main() {
-    String! name; 
-
-    name = io::readline();
-    if (catch excuse = name) {
+fn void! main() 
+{
+    String! name = io::readline();
+    if (catch excuse = name) 
+    {
         return excuse?;
     }
 
-    io::printfn("The Matrix has you... Follow the white rabbit. Knock, knock, %s.", name);
+    io::printfn("Name was: %s.", name);
 }
-```
 
 Note:
 `\r` will be filtered from the String.

--- a/src/content/docs/Standard Library/index.mdx
+++ b/src/content/docs/Standard Library/index.mdx
@@ -334,7 +334,7 @@ moving the output pointer 1 or 2 steps.
 ## std::io
 
 ### String! readline(stream = io::stdin(), Allocator allocator = allocator::heap())
-Read a String from a file stream. Defaults to standard input (stdin). Reads to the next newline or to the end of stream. Readline returns an optional, and must be handled accordingly.
+Read a `String!` from a file stream. Defaults to standard input (stdin). Reads to the next newline or to the end of stream. `Readline` returns an optional, and must be handled accordingly.
 
 ```c
 import std::io;
@@ -355,7 +355,7 @@ Note:
 `\r` will be filtered from the String.
 
 ### String! treadline(stream = io::stdin())
-Read a String from a file stream. Defaults to standard input (stdin). Reads to the next newline or to the end of stream. Readline returns an optional, and must be handled accordingly. Additionally, the difference from the regular readline, is that this uses the temporary allocator.
+Read a `String!` from a file stream. Defaults to standard input (stdin). Reads to the next newline or to the end of stream. `Treadline` returns an optional, and must be handled accordingly. Additionally, the difference from the regular `readline`, is that this uses the temporary allocator.
 
 ```c
 import std::io;
@@ -405,8 +405,9 @@ fn void main() {
 
 ### void eprint(x), void eprintn(x)
 Print any value to stderr.
-
 The `eprintn` variant appends a newline.
+
+See `print` for usage.
 
 ### usz! printf(String format, args...) @maydiscard
 Regular printf functionality: `%s`, `%x`, `%d`, `%f` and `%p` are supported.

--- a/src/content/docs/Standard Library/index.mdx
+++ b/src/content/docs/Standard Library/index.mdx
@@ -350,8 +350,9 @@ fn void! main()
     io::printfn("Name was: %s.", name);
 }
 
-Note:
+:::Note
 `\r` will be filtered from the String.
+:::
 
 ### String! treadline(stream = io::stdin())
 Read a `String!` from a file stream which is standard input (stdin) by default, Reads to the next newline character `\n` or to the end of stream. `Treadline` returns an [Optional](/language-common/optionals-essential/#what-is-an-optional) string. The temporary allocator is used by `Treadline`, in contrast the `readline` defaults to the heap allocator, but is configurable to other allocators. 

--- a/src/content/docs/Standard Library/index.mdx
+++ b/src/content/docs/Standard Library/index.mdx
@@ -359,10 +359,9 @@ Read a `String!` from a file stream which is standard input (stdin) by default, 
 ```c
 import std::io;
 
-fn void! main() {
-    String! name; 
-
-    name = io::treadline();
+fn void! main() 
+{
+    String! name = io::treadline();
     if (catch excuse = name) {
         return excuse?;
     }

--- a/src/content/docs/Standard Library/index.mdx
+++ b/src/content/docs/Standard Library/index.mdx
@@ -334,7 +334,7 @@ moving the output pointer 1 or 2 steps.
 ## std::io
 
 ### String! readline(stream = io::stdin(), Allocator allocator = allocator::heap())
-Read a String from a file stream. Defaults to standard input (stdin). Reads to the next newline or to the end of stream.
+Read a String from a file stream. Defaults to standard input (stdin). Reads to the next newline or to the end of stream. Readline returns an optional, and must be handled accordingly.
 
 ```c
 import std::io;
@@ -355,7 +355,25 @@ Note:
 `\r` will be filtered from the String.
 
 ### String! treadline(stream = io::stdin())
-Same as `readline` but uses the temporary allocator.
+Read a String from a file stream. Defaults to standard input (stdin). Reads to the next newline or to the end of stream. Readline returns an optional, and must be handled accordingly. Additionally, the difference from the regular readline, is that this uses the temporary allocator.
+
+```c
+import std::io;
+
+fn void! main() {
+    String! name; 
+
+    name = io::treadline();
+    if (catch excuse = name) {
+        return excuse?;
+    }
+
+    io::printfn("Hello %s! Hope you have a great day", name);
+}
+```
+
+Note:
+`\r` will be filtered from the String.
 
 ### void print(x), void printn(x = "")
 Print any value to stdout.

--- a/src/content/docs/Standard Library/index.mdx
+++ b/src/content/docs/Standard Library/index.mdx
@@ -371,8 +371,9 @@ fn void! main() {
 }
 ```
 
-Note:
+:::Note
 `\r` will be filtered from the String.
+:::
 
 ### void print(x), void printn(x = "")
 Print a value to stdout. Works for different types. 

--- a/src/content/docs/Standard Library/index.mdx
+++ b/src/content/docs/Standard Library/index.mdx
@@ -296,7 +296,7 @@ Same as `@clone` but uses the temporary allocator.
 
 ## std::core::types
 
-### bool is_comparable($Type)
+### bool is_comparable_value($Type)
 
 Return true if the type can be used with comparison operators.
 
@@ -334,8 +334,24 @@ moving the output pointer 1 or 2 steps.
 ## std::io
 
 ### String! readline(stream = io::stdin(), Allocator allocator = allocator::heap())
-Read from a stream (default is stdin) to the next "\n" or to the end of the stream, whatever comes first.
+Read a String from a file stream. Defaults to standard input (stdin). Reads to the next newline or to the end of stream.
 
+```c
+import std::io;
+
+fn void! main() {
+    String! name; 
+
+    name = io::readline();
+    if (catch excuse = name) {
+        return excuse?;
+    }
+
+    io::printfn("The Matrix has you... Follow the white rabbit. Knock, knock, %s.", name);
+}
+```
+
+Note:
 `\r` will be filtered from the String.
 
 ### String! treadline(stream = io::stdin())

--- a/src/content/docs/Standard Library/index.mdx
+++ b/src/content/docs/Standard Library/index.mdx
@@ -411,12 +411,39 @@ See `print` for usage.
 
 ### usz! printf(String format, args...) @maydiscard
 Regular printf functionality: `%s`, `%x`, `%d`, `%f` and `%p` are supported.
+Will also print enums and vectors. Prints to stdout.
 
-Will also print enums and vectors.
+```c
+import std::io;
+
+enum Heat {
+    WARM,
+    WARMER,
+    REALLY_WARM,
+}
+
+fn void main() {
+    int[<2>] vec = {4, 2};
+    Heat weather = REALLY_WARM;
+    String dialogue = "Hello";
+
+    io::printf("%s", dialogue);  /* Outputs: Hello    */
+    io::printf("%d", 20);        /* Outputs: 20       */
+    io::printf("%f", 2.2);       /* Outputs: 2.200000 */
+    io::printf("%s", vec);       /* Outputs: [<4, 2>] */
+    io::printf("%s", weather);   /* Outputs: REALLY_WARM */
+}
+```
 
 Also available as `printfn` which appends a newline.
 
-`eprintf` and its matching function `eprintfn` print to stderr.
+### usz! eprintf(String format, args...) @maydiscard
+Regular printf functionality: `%s`, `%x`, `%d`, `%f` and `%p` are supported.
+Will also print enums and vectors. Prints to stderr.
+
+Also available as `eprintfn` which appends a newline.
+
+See `printf` for usage
 
 ### char[]! bprintf(char[] buffer, String format, args...) @maydiscard
 Prints using a 'printf'-style formatting string, to a string buffer.

--- a/src/content/docs/Standard Library/index.mdx
+++ b/src/content/docs/Standard Library/index.mdx
@@ -334,7 +334,7 @@ moving the output pointer 1 or 2 steps.
 ## std::io
 
 ### String! readline(stream = io::stdin(), Allocator allocator = allocator::heap())
-Read a `String!` from a file stream. Defaults to standard input (stdin). Reads to the next newline or to the end of stream. `Readline` returns an optional, and must be handled accordingly.
+Read a `String!` from a file stream, which is standard input (stdin) by default, reads to the next newline character `\n` or to the end of stream. `Readline` returns an [Optional](/language-common/optionals-essential/#what-is-an-optional) string.
 
 ```c
 import std::io;


### PR DESCRIPTION
#### Simple examples added
* Fixed typo for deprecated `is_comparable` to `is_comparable_value`
* Examples for printf
* Examples for treadline
* Examples for readline