### PR TITLE
Add "String.index_of_char_from" function

### DIFF
--- a/src/content/docs/Language Common/strings.md
+++ b/src/content/docs/Language Common/strings.md
@@ -110,6 +110,10 @@ fn usz! String.index_of_char(s, char needle);
 ```
 
 ```c3 implementation
+fn usz! String.index_of_char_from(s, char needle, usz start_index);
+```
+
+```c3 implementation
 fn usz! String.index_of(s, String needle)
 ```
 


### PR DESCRIPTION
This pull request includes a small change to the `src/content/docs/Language Common/strings.md` file. The change adds the method `String.index_of_char_from` to the documentation, which I found in `std`.

Documentation updates:

* [`src/content/docs/Language Common/strings.md`](diffhunk://#diff-d38029764249883e4a31e0a5360e0043c8eb01cf53628b9bcdeefba4bc4ec444R112-R115): Added documentation for  method `String.index_of_char_from` which allows finding the index of a character starting from a specified index.