### PR TITLE
fix typo: @test cannot return void!

### DIFF
--- a/src/content/docs/Build Your Project/build-commands.mdx
+++ b/src/content/docs/Build Your Project/build-commands.mdx
@@ -88,7 +88,7 @@ Will run any tests in the project in the `"sources"` directory defined in your `
 Tests are defined with a `@test` attribute, for example:
 
 ```c3
-fn void! test_fn() @test
+fn void test_fn() @test
 {
     assert(true == true, "true is definitely true");
 }


### PR DESCRIPTION
```
1: fn void! test_fn() @test
      ^^^^^
(/Users/edw/github/c3/vector/test/test.c3:1:4) 
Error: '@test' and '@benchmark' function may only return 'void'
you can allow 'void!' by passing in '--old-test-bench=yes'.
```