### PR TITLE
Added new FAQ section for cross-compiling to Windows on Linux

### DIFF
--- a/src/content/docs/FAQ/index.mdx
+++ b/src/content/docs/FAQ/index.mdx
@@ -396,3 +396,26 @@ macro in those cases.
 Note that macros that violate the call contract, such as ones using ref arguments, need
 to have the `@` name prefix to indicate that it is indeed possibly violating 
 "value is passed by value" semantics.
+
+## Cross-compiling To Windows From Linux
+**Q:** How do I cross-compile my C3 program For Windows On Linux?
+
+**A:** With the C3 compiler you can specify which target you would like to cross-compile to.
+For Windows the following target would be needed:
+
+`c3c compile main.c3 --target windows-x64`
+
+*You need the MSVC SDK Files, which includes the Windows SDK. To be able to cross-compile to Windows*
+
+To get the MSVC SDK Files, head to your C3 directory and run the following command:
+
+`python3 msvc_build_libraries.py`
+
+Running this command should generate a msvc_sdk directory in your main C3 directory.
+
+If running this command returns an error, your Linux distribution is more than likely missing the requried packages needed for generating this msvc folder
+
+Run the following command depending on your distro:
+- **Ubuntu:** `sudo apt install msitools`
+- **Arch Linux:** `pacman -S msitools`
+- **Fedora:** `dnf install msitools`


### PR DESCRIPTION
### Added a new section on the FAQ page for cross-compilation to Windows on Linux

- Added Q/A for how to cross-compile to Windows From Linux
- Added command to download the msvc_sdk files needed for cross-compilation
- Added package manager commands for 3 Linux distros to get the needed packages if the msvc_sdk files download failed from running the python script