### PR TITLE
Fix macro and module examples

### DIFF
--- a/src/content/docs/Generic Programming/macros.md
+++ b/src/content/docs/Generic Programming/macros.md
@@ -322,12 +322,14 @@ fn void test()
 // Expands to code similar to:
 fn void test()
 {
-    int[] a = { 1, 2, 3 };
+    double[] a = { 1.0, 2.0, 3.0 };
     {
-        int[] __a = a;
-        for (int __i = 0; i < __a.len; i++)
+        double[] __a = a;
+        for (int __i = 0; __i < __a.len; __i++)
         {
-            io::printfn("Value: %d, x2: %d", __value1, __value2);
+            int __index = __i;
+            double __value = __a[__i];
+            io::printfn("a[%d] = %f", __index, __value);
         }
     }
 }

--- a/src/content/docs/Language Common/arrays.md
+++ b/src/content/docs/Language Common/arrays.md
@@ -225,16 +225,16 @@ Providing two variables to `foreach`, the first is assumed to be the index and t
 ```c3
 fn void test()
 {
-    float[4] arr = { };
+    int[4] arr = { };
     foreach (idx, &item : arr)
     {
-        item = 7 + idx; // Mutates the array element
+        *item = 7 + idx; // Mutates the array element
     }
 
     // Or equivalently, writing the types
-    foreach (int idx, Foo* &&item  : arr)
+    foreach (int idx, int* &item : arr)
     {
-        item = 7 + idx; // Mutates the array element
+        *item = 7 + idx; // Mutates the array element
     }
 }
 ```

--- a/src/content/docs/Language Fundamentals/modules.md
+++ b/src/content/docs/Language Fundamentals/modules.md
@@ -84,10 +84,10 @@ struct Context
 }
 ```
 
-`def.c3`
+`de.c3`
 
 ```c3
-module def;
+module de;
 struct Context
 {
     void* ptr;
@@ -98,7 +98,7 @@ struct Context
 
 ```c3
 module test1;
-import def, abc;
+import de, abc;
 // Context c = {} <- ambiguous
 abc::Context c = {};
 ```
@@ -131,15 +131,15 @@ local context.
 ```c3
 // File foo.c3
 module foo;
-fn void abc() @private { ... }
-fn void def() @local { ... }
+fn void abc() @private { }
+fn void de() @local { }
 
 // File foo2.c3
 module foo;
 fn void test()
 {
     abc(); // Access of private in the same module is ok
-    // def(); <- Error: function is local to foo.c3
+    // de(); <- Error: function is local to foo.c3
 }
 ```
 
@@ -443,7 +443,7 @@ fn void test()
 The include may use an absolute or relative path, the relative path is always relative to the source file in which the include appears.
 
 Note that to use it, the **trust level** of the compiler must be set to at least 2 with
-the --trust option (i.e. use `--trust=include` or `--trust=full` from the command line).
+the `--trust` option (i.e. use `--trust=include` or `--trust=full` from the command line).
 
 ### $exec
 
@@ -463,9 +463,9 @@ fn void main()
 }
 ```
 
-Using `$exec` requires **full trust level**, which is enabled with `-trust=full` from the command line.
+Using `$exec` requires **full trust level**, which is enabled with `--trust=full` from the command line.
 
-'$exec' will by default run from the `/scripts` directory for projects, for non-project builds,
+`$exec` will by default run from the `/scripts` directory for projects, for non-project builds,
 the current directory is used as well.
 
 #### `$exec` Scripting


### PR DESCRIPTION
* The macro example is stale.
* Module name cannot be a reserved name.

