### PR TITLE
Attributes doc: @callc -> @callconv

### DIFF
--- a/src/content/docs/Language Common/attributes.md
+++ b/src/content/docs/Language Common/attributes.md
@@ -85,12 +85,12 @@ Lays out the bits as if the data was stored in a big endian type, regardless of 
 Allows a macro, function, global or constant be used from another module without the module path prefixed.
 Should be used sparingly.
 
-### @callc
+### @callconv
 
 *Used for: function*
 
-Sets the call convention, which may be ignored if the convention is not supported on the target.
-Valid arguments are `veccall`, `ccall`, `stdcall`.
+Sets the calling convention, which may be ignored if the convention is not supported on the target.
+Valid arguments are `veccall`, `cdecl`, `stdcall`.
 
 ### @deprecated
 


### PR DESCRIPTION
This attribute is now `@callconv`, and `ccall` was changed to `cdecl`.

See: https://github.com/c3lang/c3c/blob/d13f302ac865251f7137410cb669c8808edd53b0/src/compiler/sema_decls.c#L2467 (function `update_call_abi_from_string`).