### PR TITLE
fix example for '$exec'

### DIFF
--- a/src/content/docs/Language Fundamentals/modules.md
+++ b/src/content/docs/Language Fundamentals/modules.md
@@ -478,7 +478,7 @@ import std::io;
 
 // Compile foo.c3 and bar.c3 in the /scripts directory, invoke the resulting binary
 // with the argument 'test'
-$exec("foo.c3;bar.c3", "test");
+$exec("foo.c3;bar.c3", { "test" });
 
 fn void main()
 {


### PR DESCRIPTION
Running the example causes a compilation error:

```bash
❯ c3c compile main.c3 --trust=full && ./main
 1: import std::io;
 2: 
 3: // On Linux or MacOS this will insert 'String a = "Hello world!";'
 4: $exec("foo.c3;bar.c3", "test");
                           ^^^^^^
(/Users/nikita/projects/c3-test/main.c3:4:24) Error: Expected '{'.
```