### PR TITLE
Nonsensical paragraph in “What is an Optional?” section

### DIFF
--- a/src/content/docs/Language Common/optionals-essential.md
+++ b/src/content/docs/Language Common/optionals-essential.md
@@ -34,9 +34,6 @@ The Optional Excuse is set with `?` after the value.
 int? b = io::FILE_NOT_FOUND?;
 ```
 
-faults are declared without namespacing, so for example `io::FILE_NOT_FOUND` is `io::FILE_NOT_FOUND`.
-Other than that semantics is unchanged.
-
 ## 🎁 Unwrapping an Optional
 :::note
 


### PR DESCRIPTION
I don't know what this paragraph is meant to communicate, but it reads nonsensically:

> faults are declared without namespacing, so for example `io::FILE_NOT_FOUND` is `io::FILE_NOT_FOUND`.
Other than that semantics is unchanged.

Do not merge. This PR is just a reminder to fix it.