### PR TITLE
centralise the download links logic and update everywhere

### DIFF
--- a/src/components/download.astro
+++ b/src/components/download.astro
@@ -1,6 +1,11 @@
 ---
-const downloadUrl = (os: string, ext = "zip") =>
-  `https://github.com/c3lang/c3c/releases/latest/download/c3-${os}.${ext}`;
+export function downloadUrl(os: string, extension: string){
+	return `https://github.com/c3lang/c3c/releases/latest/download/c3-${os}.${extension}`;
+}
+
+export function downloadUrlDebug(os: string, extension: string){
+	return `https://github.com/c3lang/c3c/releases/latest/download/c3-${os}-debug.${extension}`;
+}
 ---
 
 <div class="mt-3 flex">

--- a/src/components/link.astro
+++ b/src/components/link.astro
@@ -1,0 +1,19 @@
+---
+import { downloadUrl, downloadUrlDebug } from "./download.astro"
+
+interface Props {
+	os: string;
+	extension: string;
+}
+
+const { os, extension } = Astro.props;
+---
+
+<a href={downloadUrl(os, extension )}>
+	Download the C3 compiler.
+</a>
+Or the 
+<a href={downloadUrlDebug(os, extension)}>
+debug build
+</a>
+.

--- a/src/content/docs/Getting Started/prebuilt-binaries.mdx
+++ b/src/content/docs/Getting Started/prebuilt-binaries.mdx
@@ -4,6 +4,7 @@ description: Installing C3 Compiler Binary
 sidebar:
   order: 20
 ---
+import Link from "../../../components/link.astro"
 
 
 # Prebuilt binaries
@@ -14,7 +15,7 @@ sidebar:
 - [Installing on Arch](#installing-on-arch-linux) 
 
 ## Installing on Windows
-1.  [Download the C3 compiler](https://github.com/c3lang/c3c/releases/download/latest-prerelease/c3-windows.zip). Or the [debug build](https://github.com/c3lang/c3c/releases/download/latest/c3-windows-debug.zip)
+1. <Link os="windows" extension="zip" /> 
 2. Unzip it into a folder
 3. Either Visual Studio 17 or follow the next two steps.
 4. Run the `msvc_build_libraries.py` Python script which will download the necessary files to compile on Windows.
@@ -47,20 +48,19 @@ c3c compile ./hello.c3
 
 ## Installing on Mac Arm64
 1. Make sure you have XCode with command line tools installed.
-2. [Download the zip file](https://github.com/c3lang/c3c/releases/download/latest-prerelease/c3-macos.zip)
-   (debug version [here](https://github.com/c3lang/c3c/releases/download/latest-prerelease/c3-macos-debug.zip))
+2. <Link os="macos" extension="zip" />
 3. Unzip executable and standard lib.
 4. Run `./c3c`.
 
+
+
 ## Installing on Ubuntu
-1. [Download tar file](https://github.com/c3lang/c3c/releases/download/latest-prerelease/c3-ubuntu-22.tar.gz)
-   (debug version [here](https://github.com/c3lang/c3c/releases/download/latest-prerelease/c3-ubuntu-22-debug.tar.gz))
+1. <Link os="ubuntu-22" extension="tar.gz" />
 2. Unpack executable and standard lib.
 3. Run `./c3c`.
 
 ## Installing on Debian
-1. [Download tar file](https://github.com/c3lang/c3c/releases/download/latest-prerelease/c3-linux.tar.gz)
-   (debug version [here](https://github.com/c3lang/c3c/releases/download/latest-prerelease/c3-linux-debug.tar.gz))
+1. <Link os="linux" extension="tar.gz" />
 2. Unpack executable and standard lib.
 3. Run `./c3c`.
 


### PR DESCRIPTION
Fixes download link to use latest release, rather than prerelease and does so everywhere, frontpage and on the getting started prebuilt binaries page