### PR TITLE
Update `$defined` description

### DIFF
--- a/src/content/docs/Generic Programming/compiletime.md
+++ b/src/content/docs/Generic Programming/compiletime.md
@@ -262,7 +262,8 @@ A set of compile time functions are available at compile time:
 
 ### `$alignof`
 
-Get the alignment of something. See [reflection](/generic-programming/reflection).
+Get the alignment of something.
+See [reflection](/generic-programming/reflection/#alignof).
 
 ### `$assert`
 
@@ -289,7 +290,8 @@ fn void main()
 
 ### `$defined`
 
-Returns true if a type or identifier is defined. See [reflection](/generic-programming/reflection).
+Returns true if a type or identifier is defined.
+See [reflection](/generic-programming/reflection/#defined).
 
 ### `$echo`
 
@@ -297,7 +299,8 @@ Print a message to stdout when compiling the code.
 
 ### `$embed`
 
-Embed binary data from a file. See [expressions](/language-fundamentals/expressions/).
+Embed binary data from a file.
+See [expressions](/language-fundamentals/expressions/#including-binary-data).
 
 ### `$error`
 
@@ -305,7 +308,8 @@ When this is compiled, issue a compile time error.
 
 ### `$eval`
 
-Converts a compile time string to the corresponding variable or function. See [reflection](/generic-programming/reflection).
+Converts a compile time string to the corresponding variable or function.
+See [reflection](/generic-programming/reflection/#eval).
 
 ```c3
 fn void main()
@@ -319,7 +323,8 @@ fn void main()
 
 ### `$evaltype`
 
-Converts a compile time string to the corresponding type. See [reflection](/generic-programming/reflection).
+Converts a compile time string to the corresponding type.
+See [reflection](/generic-programming/reflection/#evaltype).
 
 ### `$exec`
 
@@ -328,7 +333,8 @@ Execute a script at compile time and include the result in the source code.
 
 ### `$extnameof`, `$qnameof` and `$nameof`
 
-Get the external name of a symbol. See [reflection](/generic-programming/reflection).
+Get the external name of a symbol.
+See [reflection](/generic-programming/reflection/#extnameof).
 
 ### `$feature`
 
@@ -344,19 +350,24 @@ Includes a file into the current file at the top level.
 
 ### `$nameof`
 
-Get the local name of a symbol. See [reflection](/generic-programming/reflection).
+Get the local name of a symbol.
+See [reflection](/generic-programming/reflection/#nameof-1).
 
 ### `$offsetof`
 
-Get the offset of a member. See [reflection](/generic-programming/reflection).
+Get the offset of a member.
+See [reflection](/generic-programming/reflection/#offsetof).
 
 ### `$qnameof`
 
-Get the qualified name of a symbol. See [reflection](/generic-programming/reflection).
+Get the qualified name of a symbol.
+See [reflection](/generic-programming/reflection/#qnameof).
 
 ### `$vacount`
 
-Return the number of macro vaarg arguments
+Return the number of macro vaarg arguments.
+For this and other vaarg compile-time functions
+[see here](/generic-programming/macros/#macro-vaargs).
 
 ### `$vaconst`
 

--- a/src/content/docs/Generic Programming/compiletime.md
+++ b/src/content/docs/Generic Programming/compiletime.md
@@ -28,7 +28,7 @@ time to concatenate arrays and strings:
 macro int[3] @foo(int $y)
 {
     int[2] $z = { 1, 2 };
-    return $z +++ $y; 
+    return $z +++ $y;
 }
 
 fn void main()
@@ -324,6 +324,7 @@ Converts a compile time string to the corresponding type. See [reflection](/gene
 ### `$exec`
 
 Execute a script at compile time and include the result in the source code.
+[See more](/language-fundamentals/modules/#exec).
 
 ### `$extnameof`, `$qnameof` and `$nameof`
 

--- a/src/content/docs/Generic Programming/reflection.md
+++ b/src/content/docs/Generic Programming/reflection.md
@@ -264,17 +264,70 @@ $alignof(g);     // => returns 4
 
 #### `$defined`
 
-Returns true if the expression inside is defined and all sub expressions are valid.
-
+Returns `true` when the expression(s) inside are defined and all sub expressions
+are valid.
 ```c3
-$defined(Foo.x);     // => returns true
-$defined(Foo.z);     // => returns false
-int[2] abc;
-$defined(abc.len);   // => returns true
-$defined(abc.len()); // => returns false
-$defined((int)abc);  // => returns false
-// $defined(abc.len() + 1)  would be an error
+$defined(Foo);       // => true
+$defined(Foo.x);     // => true
+$defined(Foo.baz);   // => false
+
+Foo foo = {};
+// Check if a method exists:
+$if $defined(foo.call):
+    // Check what the method accepts:
+    $switch :
+       $case $defined(foo.call(1)) :
+           foo.call(1);
+       $default :
+           // do nothing
+    $endswitch
+$endif
+
+// Other way to write that:
+$if $defined(foo.call, foo.call(1)):
+    foo.call(1);
+$endif
 ```
+
+The full list of what `$defined` can check:
+- `*<expr>` - checks if `<expr>` can be dereferenced, `<expr>` must already be valid
+- `<expr>[<index>]` - checks if indexing is valid, `<expr>` and `<index>` must
+    already be valid, and when possible to check at compile-time if `<index>`
+    is out of bounds this will return `false`
+- `<expr>[<index>] = <value>` - same as above, but also checks if `<value>` can
+    be assigned, `<expr>`, `<index>` and `<value>` must already be valid
+- `<expr>.<ident1>.<ident2>` - check if `.<ident2>` is valid, `<expr>.<ident1>`
+    must already be valid ("ident" is short for "identifier")
+- `ident`, `#ident`, `@ident`, `IDENT`, `$$IDENT`, `$ident` - check if identifier
+    exists
+- `Type` - check if the type exists
+- `&<expr>` - check if you can take the address of `<expr>`, `<expr>` must
+    already be valid
+- `&&<expr>` - check if you can take the
+    [temp address](https://c3-lang.org/language-fundamentals/expressions/#_top)
+    of `<expr>`, `<expr>` must already be valid
+- `$eval(<expr>)` - check if the [`$eval`](#eval) evaluates to something valid,
+    `<expr>` must already be valid
+- `<expr>(<arg0>, ...)` - check that the arguments are valid for the `<expr>`
+    macro/function, `<expr>` and all args must already be valid
+- `<expr>!!` and `<expr>!` - check that `<expr>` is an
+    [optional](/language-common/optionals-essential/#what-is-an-optional),
+    `<expr>` must already be valid
+- `<expr>?` - check that `<expr>` is a
+    [fault](/language-overview/types/#the-fault-type),
+    `<expr>` must already be valid
+- `<expr1> binary_operator <expr2>` - check if the `binary_operator` (`+`, `-`,
+    ...) is defined between the two expressions, both expressions must already
+    be valid
+- `(<Type>)<expr>` - check if `<expr>` can be casted to `<Type>`, both `<Type>`
+    and `<expr>` must already be valid
+
+If for example `<expr>` is not defined when trying `(<Type>)<expr>` this will
+result in a compile-time error.
+
+> [!WARNING]
+> Currently `<expr>[<index>] = <value>` and `<expr1> bin_op <expr2>` are not
+> correctly handled by the compiler but should be. Stay tuned!
 
 #### `$eval`
 

--- a/src/content/docs/Generic Programming/reflection.md
+++ b/src/content/docs/Generic Programming/reflection.md
@@ -325,9 +325,10 @@ The full list of what `$defined` can check:
 If for example `<expr>` is not defined when trying `(<Type>)<expr>` this will
 result in a compile-time error.
 
-> [!WARNING]
-> Currently `<expr>[<index>] = <value>` and `<expr1> bin_op <expr2>` are not
-> correctly handled by the compiler but should be. Stay tuned!
+:::caution
+Currently `<expr>[<index>] = <value>` and `<expr1> bin_op <expr2>` are not
+correctly handled by the compiler but should be. Stay tuned!
+:::
 
 #### `$eval`
 

--- a/src/content/docs/Generic Programming/reflection.md
+++ b/src/content/docs/Generic Programming/reflection.md
@@ -317,7 +317,7 @@ the one used by the linker.
 ```c3
 fn void testfn(int x) { }
 String a = $extnameof(g); // => "test.bar.g";
-string b = $extnameof(testfn); // => "test.bar.testfn"
+String b = $extnameof(testfn); // => "test.bar.testfn"
 ```
 
 #### `$nameof`

--- a/src/content/docs/Generic Programming/reflection.md
+++ b/src/content/docs/Generic Programming/reflection.md
@@ -325,10 +325,6 @@ The full list of what `$defined` can check:
 If for example `<expr>` is not defined when trying `(<Type>)<expr>` this will
 result in a compile-time error.
 
-:::caution
-Currently `<expr>[<index>] = <value>` and `<expr1> bin_op <expr2>` are not
-correctly handled by the compiler but should be. Stay tuned!
-:::
 
 #### `$eval`
 

--- a/src/content/docs/Language Fundamentals/modules.md
+++ b/src/content/docs/Language Fundamentals/modules.md
@@ -175,11 +175,11 @@ import b @public;
 fn void test()
 {
     // Error! a_function() is private
-    a::a_function(); 
+    a::a_function();
 
     // Allowed since `import b @public` allowed `b`
     // to "public" in this context.
-    b::b_function(); 
+    b::b_function();
 }
 ```
 
@@ -356,18 +356,18 @@ fn void test()
 }
 ```
 
-In this example the code would run `do_something` if available 
+In this example the code would run `do_something` if available
 (that is, when the dynamic library is 4.0 or higher), or
 fallback to `do_something_else` otherwise.
 
-If we tried to conditionally add something not available in the 
+If we tried to conditionally add something not available in the
 compilation itself, that is a compile time error:
 
 ```c3
 if (@available(dynlib::do_another_thing))
 {
     // Error: This function is not available with 3.0
-    dynlib::do_another_thing(); 
+    dynlib::do_another_thing();
 }
 ```
 
@@ -393,7 +393,7 @@ fn void testme2()
 }
 ```
 
-This allows things like optionally loading dynamic libraries on the 
+This allows things like optionally loading dynamic libraries on the
 platforms where this is available.
 
 ## Textual Includes
@@ -463,6 +463,11 @@ fn void main()
 }
 ```
 
+`$exec` can take in 1 to 3 arguments:
+- `command`/`scriptname` (`String`)
+- `args` (`String[]`): arguments passed on commandline to the command/script
+- `stdin` (`String`): text that the command/script can read from stdin
+
 Using `$exec` requires **full trust level**, which is enabled with `--trust=full` from the command line.
 
 `$exec` will by default run from the `/scripts` directory for projects, for non-project builds,
@@ -495,10 +500,10 @@ would occur, but should not be used in the general case.
 The syntax for non-recursive imports is `import <module_name> @norecurse;` for example:
 ```c3
 // Non-recursive import
-import mylib @norecurse; 
+import mylib @norecurse;
 
 // Normal import
-import mylib; 
+import mylib;
 ```
 
 For example only importing "mylib" into "my_code" and not wishing to import "submod".
@@ -526,7 +531,7 @@ fn void undesired_fn()
 
 module my_code;
 // Using Non-recursive import undesired_fn not found
-import mylib @norecurse; 
+import mylib @norecurse;
 
 // Using Recursive import undesired_fn is found
 // import mylib;
@@ -538,7 +543,7 @@ fn void main()
 }
 ```
 
-:::note 
+:::note
 You can import multiple modules in one line:
 ```c3
 import lib1, lib2;


### PR DESCRIPTION
This PR updates the description of `$defined` according to this comment: https://github.com/c3lang/c3c/issues/2118#issuecomment-2849197356 .

I also updated some links on the compile-time page to point to specific sections of the reflection page instead of just the beginning (note that `#section`s do not work with `npm run dev`, you need to build the site first and serve the result).
I did that because I was already putting some links to other docs inside the updated `$defined` and noticed that those links were annoying to use.

I added the following because I learned on Discord that there is a slight issue with the current explanation. We might want to hold off merging this PR until the `$defined` issue is solved.
![image](https://github.com/user-attachments/assets/fdaec6af-040b-4bfb-bc78-e00188d8e8fa)


