### PR TITLE
Fix 'primer' example with missing `;`

### DIFF
--- a/src/content/docs/Language Overview/primer.md
+++ b/src/content/docs/Language Overview/primer.md
@@ -358,14 +358,14 @@ return false;
 // C3, direct translation:
 do FAIL:
 {
-    Foo* foo = malloc(sizeof(Foo));
+    Foo* foo = malloc(Foo.sizeof);
 
     if (tryFoo(foo)) break FAIL;
     if (modifyFoo(foo)) break FAIL;
 
     free(foo);
     return true;
-}
+};
 free(foo);
 return false;
 


### PR DESCRIPTION
Someone posted this issue on the `c3lang/c3c` repository, but I fixed this as well. I changed `sizeof(Foo)` to `Foo.sizeof` and added the missing semicolon. Now the example properly compiles if you provide the `tryFoo` and `modifyFoo` functions. 

closes https://github.com/c3lang/c3c/issues/2312