### PR TITLE
Remove unused code

### DIFF
--- a/src/content/docs/Language Overview/types.md
+++ b/src/content/docs/Language Overview/types.md
@@ -863,7 +863,7 @@ fn void test()
 {
     Foo f;
     f.a = 2;
-    char x = (char)f;
+
     io::printfn("%d", (char)f); // prints 2
     f.b = 1;
     io::printfn("%d", (char)f); // prints 18


### PR DESCRIPTION
Remove unused code

Below code is useless, Remove it.

```
char x = (char)f; 
```