### PR TITLE
add warning that the standard library reference is outdated

### DIFF
--- a/src/content/docs/Standard Library/stdlib_refcard.md
+++ b/src/content/docs/Standard Library/stdlib_refcard.md
@@ -4,6 +4,11 @@ description: Standard Library Reference
 sidebar:
     order: 141
 ---
+
+:::caution[This page is out of date]
+While a doc generator is in development, this page is still being updated manually and will not reflect the latest stdlib changes. To view an up to date version browse the standard library source code [here](https://github.com/c3lang/c3c/tree/v0.7.4/lib/std)
+:::
+
 ### `libc`
 ```c3
 typedef Errno = inline CInt;


### PR DESCRIPTION
adds this warning to the top of the standard library ref card:

<img width="762" height="320" alt="image" src="https://github.com/user-attachments/assets/20948f36-7c9b-4eee-911d-617f7ff8e681" />

if you have any feedback on the wording etc please let me know.