### PR TITLE
Fix enum member syntax for multiple associated values

### DIFF
--- a/src/content/docs/Language Overview/examples.md
+++ b/src/content/docs/Language Overview/examples.md
@@ -800,9 +800,9 @@ import std::io, std::math::random;
 
 enum Action : (String abbrev, String full)
 {
-    ROCK = { "r", "Rock" },
-    PAPER = { "p", "Paper" },
-    SCISSORS = { "s", "Scissors" },
+    ROCK { "r", "Rock" },
+    PAPER { "p", "Paper" },
+    SCISSORS { "s", "Scissors" },
 }
 
 const ROUNDS = 3;

--- a/src/content/docs/Language Overview/types.md
+++ b/src/content/docs/Language Overview/types.md
@@ -642,9 +642,9 @@ struct Position
 
 enum State : int (String desc, bool active, Position pos)
 {
-    WAITING    = { "waiting", false, { 1, 2} },
-    RUNNING    = { "running", true,  {12,22} },
-    TERMINATED = { "ended",   false, { 0, 0} },
+    WAITING    { "waiting", false, { 1, 2} },
+    RUNNING    { "running", true,  {12,22} },
+    TERMINATED { "ended",   false, { 0, 0} },
 }
 
 fn void main()


### PR DESCRIPTION
Updated syntax for enum having multiple associated values with the new syntax