### PR TITLE
Update project config, add dynamic slices section, convert enums syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The C3 Website made with [Astro](https://astro.build/), [TailwindCSS](https://ta
 
 <h1 style="font-size: 24px;">Get Started</h1>
 
-After cloning the repository with `git clone`, you can run `npm run dev` and that's it!
+After cloning the repository with `git clone`, you need to run:
+- `npm install`
+- `npm run dev`
 
 <h1 style="display: flex; align-items: center; font-size: 24px;">Project Structure</h1>
   

--- a/src/content/docs/Build Your Project/project-config.md
+++ b/src/content/docs/Build Your Project/project-config.md
@@ -7,6 +7,8 @@ sidebar:
 # Customizing A Project
 
 This is a description of the configuration options in `project.json`:
+<br/>
+(you can see the full list executing `c3c --list-project-properties`)
 
 
 ```json5
@@ -56,6 +58,10 @@ This is a description of the configuration options in `project.json`:
   // C compiler if the project also compiles C sources
   // defaults to 'cc'.
   "cc": "cc",
+  // C compiler flags
+  "cflags": "",
+  // Set the include directories for C sources.
+  "c-include-dirs": "",
   // CPU name, used for optimizations in the LLVM backend.
   "cpu": "generic",
   // Debug information, may be "none", "full" and "line-tables".
@@ -95,6 +101,10 @@ This is a description of the configuration options in `project.json`:
   "x86cpu": "native",
   // Set max type of vector use: "none", "mmx", "sse", "avx", "avx512", "native".
   "x86vec": "sse",
+  // Enable sanitizer: none, address, memory, thread.
+  "sanitize": "none",
+  // Features enabled for all targets.
+  "features": "",
 }
 ```
         

--- a/src/content/docs/Language Common/arrays.md
+++ b/src/content/docs/Language Common/arrays.md
@@ -229,7 +229,7 @@ struct SliceRaw
 
 ### Dynamically allocated slices
 
-Standart library provides utilities for allocating multiple elements into a slice:
+Standard library provides utilities for allocating multiple elements into a slice:
 
 ```c3
 // uses calloc under the hood (memory is zeroed out)

--- a/src/content/docs/Language Common/arrays.md
+++ b/src/content/docs/Language Common/arrays.md
@@ -227,6 +227,20 @@ struct SliceRaw
 }
 ```
 
+### Dynamically allocated slices
+
+Standart library provides utilities for allocating multiple elements into a slice:
+
+```c3
+// uses calloc under the hood (memory is zeroed out)
+int[] arr1 = mem::new_array(int, 10);
+defer mem::free(arr1);
+
+// uses malloc under the hood (memory is undefined)
+int[] arr2 = mem::alloc_array(int, 10);
+defer mem::free(arr2);
+```
+
 ## Iteration Over Arrays
 
 ### `foreach` element by copy
@@ -369,10 +383,10 @@ fn void test()
 
 ## Fixed Size Multi-Dimensional Arrays
 
-To declare two dimensional fixed arrays as `<type>[<x-size>, <y-size>] arr`, like `int[4][2] arr`. Below you can see how this compares to C:
+To declare two dimensional fixed arrays as `<type>[<inner-size>, <outer-size>] arr`, like `int[4][2] arr`. Below you can see how this compares to C:
 ```c
 // C
-// Uses: name[<rows>][<columns>]
+// Uses: name[<outer-size>][<inner-size>]
 int array_in_c[4][2] = {
     {1, 2},
     {3, 4},
@@ -381,7 +395,7 @@ int array_in_c[4][2] = {
 };
 
 // C3
-// Uses: <type>[<x-size>][<y-size>]
+// Uses: <type>[<inner-size>][<outer-size>]
 // C3 declares the dimensions, inner-most to outer-most
 int[4][2] array = {
     {1, 2, 3, 4},
@@ -409,7 +423,7 @@ int[][4] array = {
 Accessing the multi-dimensional fixed array has inverted array index order to when the array was declared.
 
 ```c3
-// Uses: <type>[<x-size>][<y-size>]
+// Uses: <type>[<inner-size>][<outer-size>]
 int[2][4] array = {
     {1, 2},
     {3, 4},
@@ -417,7 +431,7 @@ int[2][4] array = {
     {7, 8},
 };
 
-// Access fixed array using: array[<row>][<column>]
+// Access fixed array using: array[<outer-index>][<inner-index>]
 int value = array[3][1]; // 8
 ```
 :::

--- a/src/content/docs/Language Overview/types.md
+++ b/src/content/docs/Language Overview/types.md
@@ -621,9 +621,9 @@ It is possible to associate each enum value with one or more a static values.
 ```c3
 enum State : int (String description)
 {
-    WAITING = "waiting",
-    RUNNING = "running",
-    TERMINATED = "ended",
+    WAITING    { "waiting" },
+    RUNNING    { "running" },
+    TERMINATED { "ended" },
 }
 
 fn void main()
@@ -1112,7 +1112,7 @@ bitstruct Implicit : int
 It is possible to use bitstructs to implement bitmasks without using the explicit masking values, see the following example:
 
 ```c3
-enum BitMaskEnum : const uint
+constdef BitMaskEnum : uint
 {
     ABC = 1 << 0,
     DEF = 1 << 1,


### PR DESCRIPTION
- fix README build instructions
- added <b>dynamically allocated slices</b> section on <b>Arrays</b> page
- project config section updated with new options
- fix enum associated values declaration syntax to '{ }' and const enum to <b>constdef</b> 