### PR TITLE
Add `@mustinit` to the docs

### DIFF
--- a/src/content/docs/FAQ/allfeatures.md
+++ b/src/content/docs/FAQ/allfeatures.md
@@ -183,7 +183,7 @@ groups certain attributes. Empty attribute groups are permitted.
 The complete list: `@align`, `@benchmark`, `@bigendian`, `@builtin`,
 `@callconv`, `@deprecated`, `@dynamic`, `@export`,
 `@cname`, `@if`, `@inline`, `@interface`,
-`@littleendian`, `@local`, `@maydiscard`, `@naked`,
+`@littleendian`, `@local`, `@maydiscard`, `@mustinit`, `@naked`,
 `@nodiscard`, `@noinit`, `@noreturn`, `@nostrip`,
 `@obfuscate`, `@operator`, `@overlap`, `@priority`,
 `@private`, `@public`, `@pure`, `@reflect`,
@@ -302,7 +302,7 @@ The complete list: `@align`, `@benchmark`, `@bigendian`, `@builtin`,
 
 ## Features provided by builtins
 
-Some features are [provided by "builtins" in the standard library](/standard-library/stdlib_refcard/#stdcorebuiltin), 
+Some features are [provided by "builtins" in the standard library](/standard-library/stdlib_refcard/#stdcorebuiltin),
 and appear like normal functions and macros in the standard library, but nonetheless provided unique functionality:
 
 1. `@likely(...)` / `@unlikely(...)` on branches affects compilation optimization.

--- a/src/content/docs/Implementation Details/grammar.md
+++ b/src/content/docs/Implementation Details/grammar.md
@@ -43,15 +43,15 @@ $vaarg      $vaexpr     $vasplat
 The following attributes are built in:
 ```
 @align        @benchmark  @bigendian  @builtin
-@cdecl        @cname      @deprecated @dynamic    
+@cdecl        @cname      @deprecated @dynamic
 @export       @extname    @inline     @interface
-@littleendian @local      @maydiscard @naked
-@nodiscard    @noinit     @noinline   @noreturn
-@nostrip      @obfuscate  @operator   @overlap
-@packed       @priority   @private    @public
-@pure         @reflect    @section    @stdcall
-@test         @unused     @used       @veccall
-@wasm         @weak       @winmain
+@littleendian @local      @maydiscard @mustinit
+@naked        @nodiscard  @noinit     @noinline
+@noreturn     @nostrip    @obfuscate  @operator
+@overlap      @packed     @priority   @private
+@public       @pure       @reflect    @section
+@stdcall      @test       @unused     @used
+@veccall      @wasm       @weak       @winmain
 ```
 
 The following constants are defined:

--- a/src/content/docs/Implementation Details/specification.md
+++ b/src/content/docs/Implementation Details/specification.md
@@ -150,7 +150,7 @@ $alignof   $assert     $assignable
 $case      $default    $defined
 $echo      $else       $embed
 $endfor    $endforeach $endif
-$endswitch $eval       $error     
+$endswitch $eval       $error
 $exec      $extnameof  $feature
 $for       $foreach    $if
 $include   $is_const   $nameof
@@ -172,8 +172,8 @@ The following character sequences represent operators and punctuation.
 (       )       *       [       ]       %
 >=      <=      +       +=      -=      !
 ?       ?:      &&      ??      &=      |=
-^=      /=      ..      ==      [<      >]      
-++      --      %=      !=      ||      ::      
+^=      /=      ..      ==      [<      >]
+++      --      %=      !=      ||      ::
 <<      >>      !!      ->      =>      ...
 <<=     >>=     +++     &&&    |||      ???
 ```
@@ -509,7 +509,7 @@ TODO
 
 ## Expressions
 
-TOTO 
+TOTO
 
 ### Assignment expression
 
@@ -763,6 +763,10 @@ If no init expression is provided, the variable is **zero initialized**.
 #### Opt-out of zero initialization
 
 Using the @noinit attribute opts out of **zero initialization**.
+
+#### Prevent opt-out of zero initialization
+
+Using the @mustinit attribute disables the use of the @noinit attribute.
 
 #### Self referencing initialization
 
@@ -1300,9 +1304,10 @@ Attributes are modifiers attached to modules, variables, type declarations etc.
 | `@littleendian` | bitstruct only                                                                    |
 | `@local`        | module, fn, macro, globals, constants, user-defined types, attributes and aliases |
 | `@maydiscard`   | fn, macro                                                                         |
+| `@mustinit`     | variables                                                                         |
 | `@naked`        | fn                                                                                |
 | `@nodiscard`    | fn, macro                                                                         |
-| `@noinit`       | variables                                                                         |
+| `@noinit`       | user-defined types
 | `@noinline`     | fn, call                                                                          |
 | `@noreturn`     | fn, macro                                                                         |
 | `@nostrip`      | fn, globals, constants, struct, union, enum, faultdef                             |

--- a/src/content/docs/Implementation Details/specification.md
+++ b/src/content/docs/Implementation Details/specification.md
@@ -509,7 +509,7 @@ TODO
 
 ## Expressions
 
-TOTO
+TODO
 
 ### Assignment expression
 

--- a/src/content/docs/Language Common/attributes.md
+++ b/src/content/docs/Language Common/attributes.md
@@ -170,6 +170,12 @@ Sets the visibility to "local", which means it's only visible in the current mod
 Allows the return value of the function or macro to be discarded even if it is an optional. Should be
 used sparingly.
 
+### `@mustinit`
+
+*Used for: user-defined types*
+
+Prevents the use of the `@noinit` tag on a variable of the specified type.
+
 ### `@naked`
 
 *Used for: function*


### PR DESCRIPTION
@NotsoanoNimus added the `@mustinit` tag to the compiler, but I did not see any documentation added to the docs website, hence this quick PR.

I created this by searching for `@noinit` locally, and everywhere it occurs I added the `@mustinit` explanation, excepting in the following files:
- `src/content/docs/Language Overview/primer.md`
- `src/content/docs/FAQ/changesfromc.md`

I hope this helps. If more info (examples?) need to be added, feel free to ask or add yourself. 