### PR TITLE
Bump homepage version frmo 0.7.10 to 0.7.11

### DIFF
--- a/src/components/hero.astro
+++ b/src/components/hero.astro
@@ -104,7 +104,7 @@
       <span class="text-sm text-gray-600 dark:text-gray-400"
         >Current version:
       </span>
-      <span class="text-sm font-bold text-gray-900 dark:text-white">0.7.10</span>
+      <span class="text-sm font-bold text-gray-900 dark:text-white">0.7.11</span>
       <svg
         class="h-5 w-5 text-gray-300 dark:text-gray-600"
         width="16"


### PR DESCRIPTION
The homepage of the website still is on 0.7.10, while 0.7.11 is released and has a blog post.

<img width="390" height="378" alt="image" src="https://github.com/user-attachments/assets/8036baac-02bc-47ab-a229-9e6fd8d4aede" />
