### PR TITLE
add "Single page" plugin

### DIFF
--- a/docs/c-to-c3/a-guide-for-c-programmers.md
+++ b/docs/c-to-c3/a-guide-for-c-programmers.md
@@ -408,7 +408,7 @@ fn void testme()
 
 </div>
 
-Read more about enums [here](types.md#enum).
+Read more about enums [here](../language-common/enums.md).
 
 ### Bitfields Are Replaced By Explicit Bitstructs
 

--- a/docs/getting-started/design-goals.md
+++ b/docs/getting-started/design-goals.md
@@ -34,7 +34,7 @@ state.*
 - [Zero overhead errors](../language-common/optionals-essential.md#what-is-an-optional)
 - [Semantic macro system](../generic-programming/macros.md)
 - [First-class SIMD vector types](../language-common/vectors.md)
-- [Struct subtyping](../language-overview/types.md#struct-subtyping)
+- [Struct subtyping](../language-common/structs-and-unions.md#struct-subtyping)
 - [Safe array access using slices](../language-common/arrays.md#slice)
 - [Safe array iteration using foreach](../language-common/arrays.md#iteration-over-arrays)
 - [Easy to use inline assembly](../misc-advanced/asm.md)

--- a/docs/language-common/enums.md
+++ b/docs/language-common/enums.md
@@ -22,7 +22,7 @@ State current_state = WAITING; // or '= State.WAITING'
 The access requires referencing the `enum`'s name as `State.WAITING` because
 an enum like `State` is a separate namespace by default, just like C++'s class `enum`.
 
-Standard enums are always backed by an ordinal value running from zero and up, without any gaps. For enums for non-consecutive values, see [constdef](#constdef). To create enums that implement a bit-mask, you can also consider using [bitstructs](#bitstructs-as-bit-masks).
+Standard enums are always backed by an ordinal value running from zero and up, without any gaps. For enums for non-consecutive values, see [constdef](#constdef). To create enums that implement a bit-mask, you can also consider using [bitstructs](bitstructs.md#bitstructs-as-bit-masks).
 
 ### Enum associated values
 

--- a/docs/language-common/strings.md
+++ b/docs/language-common/strings.md
@@ -27,7 +27,6 @@ typedef ZString = inline char*;
 `ZString` is used when working with C code, which expects null-terminated C-style strings of type `char*`.
 It is a `typedef` so converting to a `ZString` requires an explicit cast. This helps to remind the user to check there is appropriate `\0` termination of the string data.
 
-The [`ZString` methods](#zstring-member-functions) are outlined below.
 
 !!! caution
     Ensure the terminal `\0` when converting from `String` to `ZString`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,22 @@ plugins:
       post_url_format: "{slug}"
   - git-revision-date-localized:
       type: datetime
+  - print-site: # print-site must be at the bottom of the plugin list
+      add_cover_page: false
+      add_to_navigation: true
+      print_page_title: 'Print Site'
+      print_page_basename: 'print_page'
+      # Table of contents
+      add_table_of_contents: true
+      toc_title: 'Table of Contents'
+      toc_depth: 3
+      enumerate_headings: true
+      enumerate_figures: false
+      add_cover_page: false
+      exclude:
+        - index.md
+        - blog/*
+
 hooks:
   - hooks/c3_lexer.py
   - hooks/latest_version.py # gets the "latest" version from `c3lang/c3c`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,8 +77,8 @@ plugins:
   - print-site: # print-site must be at the bottom of the plugin list
       add_cover_page: false
       add_to_navigation: true
-      print_page_title: 'Print Site'
-      print_page_basename: 'print_page'
+      print_page_title: 'Single Page Docs'
+      print_page_basename: 'all'
       # Table of contents
       add_table_of_contents: true
       toc_title: 'Table of Contents'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "mkdocs-git-revision-date-localized-plugin>=1.5.1",
     "mkdocs-material>=9.7.6",
     "mkdocs-minify-plugin>=0.8.0",
+    "mkdocs-print-site-plugin>=2.8",
     "pymdown-extensions>=10.21.2",
 ]
 


### PR DESCRIPTION
https://c3-lang.org/print_page/ would show the whole docs, excluding the
blog, in a single page. Nice for PDF printing.

Add a link in the left navbar: "Print Site". Can be configured from
`mkdocs.yml`

Fixes issue: https://github.com/c3lang/c3-web/issues/91