### PR TITLE
Clarify 'isz' renaming to 'sz' in documentation

### DIFF
--- a/docs/language-fundamentals/basic-types-and-values.md
+++ b/docs/language-fundamentals/basic-types-and-values.md
@@ -34,7 +34,7 @@ between two pointers. For each signed integer type there is a corresponding unsi
 On 64-bit machines `iptr`/`uptr` and `isz`/`usz` are usually 64-bits, like `long`/`ulong`.
 On 32-bit machines on the other hand they are generally `int`/`uint`.
 
-*Note: from 0.8.0 and onward, `isz` is renamed `sz` and is used as the default.*
+*Note: from 0.8.0 and onward, `isz` is renamed `sz` and is used as the default. (see [https://c3-lang.org/blog/unsigned-sizes-a-five-year-mistake/]())*
 
 ### Integer constants
 


### PR DESCRIPTION
Updated note about 'isz' renaming to 'sz' with a reference link.