### PR TITLE
Enhance macros documentation for vaargs

### DIFF
--- a/docs/generic-programming/macros.md
+++ b/docs/generic-programming/macros.md
@@ -440,9 +440,9 @@ Nor is `$vasplat` limited to function arguments. You can also use `$vasplat` wit
 int[*] a = { 5, $vasplat[2..], 77 };
 ```
 
-### In 0.8+
+### 0.8.0+
 
-In 0.8+, all operations on the arguments are done through the built-in keyword `$vaarg`:
+In 0.8.0+, all operations on the arguments are done through the built-in keyword `$vaarg`:
 
 ```c3
 macro compile_time_sum(...)
@@ -467,14 +467,14 @@ Returns the number of arguments passed into the macro's vaarg list.
 Returns the argument at index `idx` as an unevaluated expression. Multiple uses will
 evaluate the expression multiple times. This corresponds to `#` parameters.
 
-#### `$strigify($vaarg[idx])`
+#### `$stringify($vaarg[idx])`
 
 Will return the expression at the index `idx` as a string. It is equivalent to `$stringify(#param)`.
 ```c3
 macro dbg(...)
 {
     $for int $i = 0; $i < $vaarg.len; $i++:
-        io::printfn("%s=%s", $stringify($vaarg[$i]), $vaarg[$i]);
+        io::printfn("%s = %s", $stringify($vaarg[$i]), $vaarg[$i]);
     $endfor
 }
 
@@ -483,8 +483,8 @@ double y = 22.98
 
 dbg(x, y)
 // Will print
-// x=111
-// y=22.98
+// x = 111
+// y = 22.98
 ```
 
 #### `$typefrom($vaarg[idx])`

--- a/docs/generic-programming/macros.md
+++ b/docs/generic-programming/macros.md
@@ -384,7 +384,8 @@ The maximum recursion depth is limited to the `macro-recursion-depth` build sett
 Macros support the typed vaargs used by C3 functions: `macro void foo(int... args)` and `macro void bar(args...)`
 but also support a unique set of macro vaargs that look like C-style vaargs: `macro void baz(...)`.
 
-To access the arguments there is a family of $va-* built-in functions to retrieve
+### In 0.7.x
+In 0.7.x, to access the arguments there is a family of $va-* built-in functions to retrieve
 the arguments:
 
 ```c3
@@ -401,32 +402,32 @@ $if compile_time_sum(1, 3) > 2: // Will compile to $if 4 > 2
 $endif
 ```
 
-### `$vacount`
+#### `$vacount`
 
 Returns the number of arguments passed into the macro's vaarg list.
 
-### `$vaarg`
+#### `$vaarg`
 
 Returns the argument as a regular parameter. The argument is
 guaranteed to be evaluated once, even if the argument is used multiple times.
 
-### `$vaconst`
+#### `$vaconst`
 
 Returns the argument as a compile time constant, this is suitable for
 placing in a compile time variable or use for compile time evaluation,
 e.g. `$foo = $vaconst[1]`. This corresponds to `$` parameters.
 
-### `$vaexpr`
+#### `$vaexpr`
 
 Returns the argument as an unevaluated expression. Multiple uses will
 evaluate the expression multiple times. This corresponds to `#` parameters.
 
-### `$vatype`
+#### `$vatype`
 
 Returns the argument as a type. This corresponds to `$Type` style parameters,
 e.g. `$vatype[2] a = 2`.
 
-### `$vasplat`
+#### `$vasplat`
 
 `$vasplat` allows you to paste the vaargs in the call into another call. For example,
 if the macro was called with values `"foo"` and `1`, the code `foo($vasplat)`, would become `foo("foo", 1)`. 
@@ -437,6 +438,70 @@ Nor is `$vasplat` limited to function arguments. You can also use `$vasplat` wit
 
 ```c3
 int[*] a = { 5, $vasplat[2..], 77 };
+```
+
+### In 0.8+
+
+In 0.8+, all operations on the arguments are done through the built-in keyword `$vaarg`:
+
+```c3
+macro compile_time_sum(...)
+{
+    var $x = 0;
+    $for var $i = 0; $i < $vaarg.len; $i++:
+        $x += $vaarg[$i];
+    $endfor
+    return $x;
+}
+$if compile_time_sum(1, 3) > 2: // Will compile to $if 4 > 2
+    ...
+$endif
+```
+
+#### `$vaarg.len`
+
+Returns the number of arguments passed into the macro's vaarg list.
+
+#### `$vaarg[idx]`
+
+Returns the argument at `idx`. The argument is guaranteed to be evaluated once, even if the argument is used multiple times.
+
+#### `$strigify($vaarg[idx])`
+
+Will return the expression at the index `idx` as a string. It is equivalent to `$stringify(#param)`.
+```c3
+macro dbg(...)
+{
+    $for int $i = 0; $i < $vaarg.len; $i++:
+        io::printfn("%s=%s", $stringify($vaarg[$i]), $vaarg[$i]);
+    $endfor
+}
+
+int x = 111
+double y = 22.98
+
+dbg(x, y)
+// Will print
+// x=111
+// y=22.98
+```
+
+#### `$typefrom($vaarg[$idx])`
+
+Will treat the argument at the index `$idx` as a type. It is equivalent to the old `$vatype` and corresponds to `$Type` parameters.
+e.g. `$typefrom($vaarg[2]) a = 2`.
+
+#### `...$vaarg` (splatting)
+
+`...$vaarg` allows you to paste the vaargs in the call into another call. For example,
+if the macro was called with values `"foo"` and `1`, the code `foo(...$vaarg)`, would become `foo("foo", 1)`. 
+
+You can even extract a range of arguments from the splat: `...$vaarg[2..4]`. In this case, doing so would paste in arguments 2, 3 and 4.
+
+Nor is `...$vaarg` limited to function arguments. You can also use `...$vaarg` within initializers. For example:
+
+```c3
+int[*] a = { 5, ...$vaarg[2..], 77 };
 ```
 
 ## Untyped lists

--- a/docs/generic-programming/macros.md
+++ b/docs/generic-programming/macros.md
@@ -464,7 +464,8 @@ Returns the number of arguments passed into the macro's vaarg list.
 
 #### `$vaarg[idx]`
 
-Returns the argument at `idx`. The argument is guaranteed to be evaluated once, even if the argument is used multiple times.
+Returns the argument at index `idx` as an unevaluated expression. Multiple uses will
+evaluate the expression multiple times. This corresponds to `#` parameters.
 
 #### `$strigify($vaarg[idx])`
 
@@ -486,9 +487,9 @@ dbg(x, y)
 // y=22.98
 ```
 
-#### `$typefrom($vaarg[$idx])`
+#### `$typefrom($vaarg[idx])`
 
-Will treat the argument at the index `$idx` as a type. It is equivalent to the old `$vatype` and corresponds to `$Type` parameters.
+Will treat the argument at the index `idx` as a type. It is equivalent to the old `$vatype` and corresponds to `$Type` parameters.
 e.g. `$typefrom($vaarg[2]) a = 2`.
 
 #### `...$vaarg` (splatting)


### PR DESCRIPTION
Updated documentation for macro vaargs in versions 0.7.x and 0.8+, detailing built-in functions and their usage.