### PR TITLE
Add `c3lang.org/compare` shortlink and a mention of `resources/examples/` folder

### DIFF
--- a/docs/language-overview/examples.md
+++ b/docs/language-overview/examples.md
@@ -7,6 +7,8 @@ search:
 ## Overview
 This is meant for a quick reference, to learn more of the details, check the relevant sections.
 
+For a richer catalogue of example projects and scripts covering various themes and difficulties, check out the [C3 compiler's resources/examples directory](https://github.com/c3lang/c3c/tree/master/resources/examples).
+
 ## If Statement
 ```c3
 fn void if_example(int a)

--- a/hooks/shortlinks.py
+++ b/hooks/shortlinks.py
@@ -8,7 +8,8 @@ def on_post_build(config, **kwargs):
         'reference':        {'target': 'standard-library/docs.html',  'title': 'C3 Standard Library Documentation'},
         'refcard':          {'target': 'standard-library/docs.html',  'title': 'C3 Standard Library Documentation'},
         'lib':              {'target': 'standard-library/docs.html',  'title': 'C3 Standard Library Documentation'},
-        'docs':             {'target': 'language-overview/examples/', 'title': 'C3 Documentation Examples'}
+        'docs':             {'target': 'language-overview/examples/', 'title': 'C3 Documentation Examples'},
+        'compare':          {'target': 'faq/compare-languages/',      'title': 'C3 Comparison with other languages'}
     }
 
     template = """

--- a/hooks/shortlinks.py
+++ b/hooks/shortlinks.py
@@ -9,7 +9,8 @@ def on_post_build(config, **kwargs):
         'refcard':          {'target': 'standard-library/docs.html',  'title': 'C3 Standard Library Documentation'},
         'lib':              {'target': 'standard-library/docs.html',  'title': 'C3 Standard Library Documentation'},
         'docs':             {'target': 'language-overview/examples/', 'title': 'C3 Documentation Examples'},
-        'compare':          {'target': 'faq/compare-languages/',      'title': 'C3 Comparison with other languages'}
+        'compare':          {'target': 'faq/compare-languages/',      'title': 'C3 Comparison with other languages'},
+        'spec':             {'target': 'implementation-details/specification/', 'title': 'C3 Specification'}
     }
 
     template = """


### PR DESCRIPTION
- Add a mention of resources/examples/ to examples.md https://github.com/c3lang/c3-web/issues/49
- Add shortlink c3lang.org/compare -> faq/compare-languages/ https://github.com/c3lang/c3-web/issues/66