### PR TITLE
clarify support for `jsonc`

### DIFF
--- a/docs/build-your-project/project-config.md
+++ b/docs/build-your-project/project-config.md
@@ -4,7 +4,7 @@ description: Project Configuration
 ---
 # Customizing A Project
 
-This is a description of the configuration options in `project.json`:
+This is a description of the configuration options in `project.json5` or `project.json`:
 <br/>
 (you can see the full list executing `c3c --list-project-properties`)
 


### PR DESCRIPTION
Updated the description to include `project.json5` as a valid configuration file from `src/utils/common.h`