### PR TITLE
Fix weird backslashes in the documentation page for strings

### DIFF
--- a/docs/language-common/strings.md
+++ b/docs/language-common/strings.md
@@ -7,23 +7,20 @@ In C3, multiple string types are available, each suited to different use cases.
 ### `String`
 
 ```c3
-
 typedef String = inline char[];
-
 ```
-`String`s are usually the typical type to use, they can be sliced, compared etc ...
+
+- `String`s are usually the typical type to use, they can be sliced, compared etc ...
 It is possible to access the length of a `String` instance through the  ` .len  `  operator.
 
 
 ### `ZString`
 
 ```c3
-
 typedef ZString = inline char*;
 ```
 
-
-`ZString` is used when working with C code, which expects null-terminated C-style strings of type `char*`.
+- `ZString` is used when working with C code, which expects null-terminated C-style strings of type `char*`.
 It is a `typedef` so converting to a `ZString` requires an explicit cast. This helps to remind the user to check there is appropriate `\0` termination of the string data.
 
 
@@ -33,18 +30,15 @@ It is a `typedef` so converting to a `ZString` requires an explicit cast. This h
 #### `WString`
 
 ```c3
-
 typedef WString = inline Char16*;
 ```
 
-The `WString` type is similar to `ZString` but uses `Char16*`, typically for UTF-16 encoded strings. This type is useful for applications where 16-bit character encoding is required.
+- The `WString` type is similar to `ZString` but uses `Char16*`, typically for UTF-16 encoded strings. This type is useful for applications where 16-bit character encoding is required.
 
 #### `DString`
 
 ```c3
-
 typedef DString (OutStream) = void*;
 ```
 
-`DString` is a dynamic string builder that supports various string operations at runtime, allowing for flexible manipulation without the need for manual memory allocation.
-
+- `DString` is a dynamic string builder that supports various string operations at runtime, allowing for flexible manipulation without the need for manual memory allocation.

--- a/docs/language-common/strings.md
+++ b/docs/language-common/strings.md
@@ -11,8 +11,7 @@ In C3, multiple string types are available, each suited to different use cases.
 typedef String = inline char[];
 
 ```
-\
-`String`s are usually the typical type to use, they can be sliced, compared etc ... \
+`String`s are usually the typical type to use, they can be sliced, compared etc ...
 It is possible to access the length of a `String` instance through the  ` .len  `  operator.
 
 
@@ -38,7 +37,6 @@ It is a `typedef` so converting to a `ZString` requires an explicit cast. This h
 typedef WString = inline Char16*;
 ```
 
-\
 The `WString` type is similar to `ZString` but uses `Char16*`, typically for UTF-16 encoded strings. This type is useful for applications where 16-bit character encoding is required.
 
 #### `DString`
@@ -48,6 +46,5 @@ The `WString` type is similar to `ZString` but uses `Char16*`, typically for UTF
 typedef DString (OutStream) = void*;
 ```
 
-\
 `DString` is a dynamic string builder that supports various string operations at runtime, allowing for flexible manipulation without the need for manual memory allocation.
 


### PR DESCRIPTION
I was looking at the documentation page for strings and saw random backslashes therewithin, this edit removes those random backslashes