### PR TITLE
Update attribute @test to add use on 'module'

### DIFF
--- a/docs/language-common/attributes.md
+++ b/docs/language-common/attributes.md
@@ -313,10 +313,11 @@ it using `$reflect`: `$reflect(my_global).has_tag("bar")`.
 
 ### `@test`
 
-*Used for: function*
+*Used for: module, function*
 
-Marks the function as a test function. Will be added to the list of test functions when the tests are run,
-otherwise the function will not be included in the compilation.
+Marks the function or all functions inside the module section, as a test
+function. They will be added to the list of test functions when the tests are
+run, otherwise the function(s) will not be included in the compilation.
 
 ### `@unused`
 


### PR DESCRIPTION
The docs for the `@test` attribute did not mention the capability of it working on entire modules. This PR updates the description so that this use is included.