### PR TITLE
Blog feed with RSS

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,16 @@ plugins:
       post_url_format: "{slug}"
   - git-revision-date-localized:
       type: datetime
+  - rss:
+      feed_title: 'The C3 blog'
+      match_path: "^blog/posts/.*"
+      image: "assets/logo.png"
+      length: 20
+      date_from_meta:
+        as_creation: date
+      categories:
+        - categories
+        - tags
   - print-site: # print-site must be at the bottom of the plugin list
       add_cover_page: false
       add_to_navigation: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "mkdocs-material>=9.7.6",
     "mkdocs-minify-plugin>=0.8.0",
     "mkdocs-print-site-plugin>=2.8",
+    "mkdocs-rss-plugin>=1.19.0",
     "pymdown-extensions>=10.21.2",
 ]
 


### PR DESCRIPTION
Add a RSS feed for blog articles.
A setting instructs the plugin to extract dates from the post themselves rather than from git.
I found the git dates to be unreliable.

Fixes #259
